### PR TITLE
Fix #17 GitHubActions用ファイルの配置変更と内容の修正

### DIFF
--- a/.github/workflows/heroku.yml
+++ b/.github/workflows/heroku.yml
@@ -2,10 +2,14 @@ name: Deploy Heroku
 on:
   push:
     branches: main
+    paths: 'back/**'
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: back
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
## issue番号
#17 

## やったこと
ルートディレクトリに配置されていなかったため、自動デプロイがされなかった問題に対処
- 自動デプロイ用ファイルをルート直下の.githubディレクトリに移動
- backディレクトリに変更があったときに実行するよう追記
- 作業ディレクトリをbackにするよう追記

## できなかったこと・やらなかったこと


## できるようになること（ユーザ目線）


## できなくなること（ユーザ目線）


## 動作確認


## その他
- [GitHub Actions で作業ディレクトリを変更する方法。](https://ebc-2in2crc.hatenablog.jp/entry/2023/01/13/181801)