### PR TITLE
[Add] User情報をDBに保存する

### DIFF
--- a/back/app/controllers/api/v1/users_controller.rb
+++ b/back/app/controllers/api/v1/users_controller.rb
@@ -1,0 +1,16 @@
+class Api::V1::UsersController < ApplicationController
+  def create
+    user = User.find_by(provider: params[:provider], provider_id: params[:provider_id])
+    if !user
+      user = User.create(provider: params[:provider], provider_id: params[:provider_id], name: params[:name])
+    end
+    if user
+      head :ok
+    else
+      render json: { error: "ログインに失敗しました" }, status: :unprocessable_entity
+    end
+    rescue StandardError => e
+      render json: { error: e.message }, status: :internal_server_error
+    end
+  end
+end

--- a/back/app/controllers/api/v1/users_controller.rb
+++ b/back/app/controllers/api/v1/users_controller.rb
@@ -1,11 +1,11 @@
 class Api::V1::UsersController < ApplicationController
   def create
-    user = User.find_by(provider: params[:provider], provider_id: params[:provider_id])
-    if !user
-      user = User.create(provider: params[:provider], provider_id: params[:provider_id], name: params[:name])
+    @user = User.find_by(provider: params[:provider], provider_id: params[:provider_id])
+    if !@user
+      @user = User.create(provider: params[:provider], provider_id: params[:provider_id], name: params[:name])
     end
-    if user
-      head :ok
+    if @user
+      render json: @user, head :ok
     else
       render json: { error: "ログインに失敗しました" }, status: :unprocessable_entity
     end

--- a/back/app/controllers/api/v1/users_controller.rb
+++ b/back/app/controllers/api/v1/users_controller.rb
@@ -1,14 +1,15 @@
 class Api::V1::UsersController < ApplicationController
   def create
-    @user = User.find_by(provider: params[:provider], provider_id: params[:provider_id])
-    if !@user
-      @user = User.create(provider: params[:provider], provider_id: params[:provider_id], name: params[:name])
-    end
-    if @user
-      render json: @user, head :ok
-    else
-      render json: { error: "ログインに失敗しました" }, status: :unprocessable_entity
-    end
+    begin
+      @user = User.find_by(provider: params.dig(:user, :provider), provider_id: params.dig(:user, :providerId))
+      if !@user
+        @user = User.create(provider: params.dig(:user, :provider), provider_id: params.dig(:user, :providerId), name: params.dig(:user, :name))
+      end
+      if @user
+        render json: @user, status: :ok
+      else
+        render json: { error: "ログインに失敗しました" }, status: :unprocessable_entity
+      end
     rescue StandardError => e
       render json: { error: e.message }, status: :internal_server_error
     end

--- a/back/app/models/application_record.rb
+++ b/back/app/models/application_record.rb
@@ -1,3 +1,5 @@
 class ApplicationRecord < ActiveRecord::Base
+  include UuidModule
+
   primary_abstract_class
 end

--- a/back/app/models/concerns/uuid_module.rb
+++ b/back/app/models/concerns/uuid_module.rb
@@ -1,0 +1,14 @@
+module UuidModule
+  extend ActiveSupport::Concern
+
+  included do
+    before_create :generate, if: -> { has_attribute?(:id) }
+  end
+
+  def generate
+    self.id ||= loop do
+      uuid = SecureRandom.uuid
+      break uuid unless self.class.exists?(id: uuid)
+    end
+  end
+end

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -1,0 +1,2 @@
+class User < ApplicationRecord
+end

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-
+  post 'auth/:provider/callback', to: 'api/v1/users#create'
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -1,10 +1,14 @@
 Rails.application.routes.draw do
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-  post 'auth/:provider/callback', to: 'api/v1/users#create'
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check
 
   # Defines the root path route ("/")
   # root "posts#index"
+  namespace :api do
+    namespace :v1 do
+      resources :users, only: %i[create]
+    end
+  end
 end

--- a/back/db/migrate/20250206020756_create_users.rb
+++ b/back/db/migrate/20250206020756_create_users.rb
@@ -1,0 +1,11 @@
+class CreateUsers < ActiveRecord::Migration[7.2]
+  def change
+    create_table :users, id: :string, limit: 36 do |t|
+      t.string :provider, null: false
+      t.string :provider_id, null: false
+      t.string :name, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -1,0 +1,21 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.2].define(version: 2025_02_06_020756) do
+  create_table "users", id: { type: :string, limit: 36 }, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "provider", null: false
+    t.string "provider_id", null: false
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+end

--- a/compose.yaml
+++ b/compose.yaml
@@ -11,6 +11,9 @@ services:
       - bundle_data:/usr/local/bundle
     ports:
       - "3306:3306"
+    networks:
+      fixed_compose_network:
+        ipv4_address: 172.20.0.4
   back:
     build:
       context: ./back
@@ -22,6 +25,9 @@ services:
       - "3000:3000"
     depends_on:
       - db
+    networks:
+      fixed_compose_network:
+        ipv4_address: 172.20.0.3
     tty: true
     stdin_open: true
     environment:
@@ -36,6 +42,15 @@ services:
     command: yarn dev -p 8000
     ports:
       - "8000:8000"
+    networks:
+      fixed_compose_network:
+        ipv4_address: 172.20.0.2
 volumes:
   mysql_data:
   bundle_data:
+networks:
+  fixed_compose_network:
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.20.0.0/24

--- a/front/auth.config.ts
+++ b/front/auth.config.ts
@@ -2,8 +2,5 @@ import type { NextAuthConfig } from "next-auth";
 import Google from "next-auth/providers/google";
 
 export const authConfig: NextAuthConfig = {
-  providers: [ Google({
-    clientId: process.env.GOOGLE_CLIENT_ID,
-    clientSecret: process.env.GOOGLE_CLIENT_SECRET,
-  }) ]
+  providers: [ Google ]
 }

--- a/front/lib/api/user.ts
+++ b/front/lib/api/user.ts
@@ -22,6 +22,6 @@ export const getOrCreateUser = async (provider: string, providerId: string, name
 }
 
 export const getOrCreateUserId = async (provider: string, providerId: string, name: string | null | undefined) => {
-  let user = await getOrCreateUser(provider, providerId, name)
+  const user = await getOrCreateUser(provider, providerId, name)
   return user.id;
 }

--- a/front/lib/api/user.ts
+++ b/front/lib/api/user.ts
@@ -1,0 +1,22 @@
+export const getUserById = async (id: string) => {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/${process.env.NEXT_PUBLIC_API_VERSION}/users/${id}`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    cache: 'no-cache',
+  });
+  return res.json();
+}
+
+export const createUser = async (provider: string, providerId: string, name: string) => {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/${process.env.NEXT_PUBLIC_API_VERSION}/users`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ user: { provider: provider, providerId: providerId, name: name } }),
+    cache: 'no-cache',
+  });
+  return res.json();
+}

--- a/front/lib/api/user.ts
+++ b/front/lib/api/user.ts
@@ -1,15 +1,15 @@
-export const getUserById = async (id: string) => {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/${process.env.NEXT_PUBLIC_API_VERSION}/users/${id}`, {
-    method: 'GET',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    cache: 'no-cache',
-  });
-  return res.json();
-}
+// export const getUserById = async (id: string) => {
+//   const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/${process.env.NEXT_PUBLIC_API_VERSION}/users/${id}`, {
+//     method: 'GET',
+//     headers: {
+//       'Content-Type': 'application/json',
+//     },
+//     cache: 'no-cache',
+//   });
+//   return res.json();
+// }
 
-export const createUser = async (provider: string, providerId: string, name: string) => {
+export const getOrCreateUser = async (provider: string, providerId: string, name: string | null | undefined) => {
   const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/${process.env.NEXT_PUBLIC_API_VERSION}/users`, {
     method: 'POST',
     headers: {
@@ -19,4 +19,9 @@ export const createUser = async (provider: string, providerId: string, name: str
     cache: 'no-cache',
   });
   return res.json();
+}
+
+export const getOrCreateUserId = async (provider: string, providerId: string, name: string | null | undefined) => {
+  let user = await getOrCreateUser(provider, providerId, name)
+  return user.id;
 }

--- a/front/types/next-auth.d.ts
+++ b/front/types/next-auth.d.ts
@@ -1,0 +1,15 @@
+import type { JWT } from "next-auth/jwt";
+
+// Session を拡張
+declare module "next-auth" {
+  interface Session {
+    user: ExtendedUser;
+  }
+}
+
+// JWT を拡張
+declare module "next-auth/jwt" {
+  interface JWT {
+    idToken: string;
+  }
+}


### PR DESCRIPTION
## issue番号
close #6 

## やったこと
【back】
- Userモデルを作成
- usersコントローラーの作成、users#createのAPIエンドポイントを生成
- users#createでは、DBに登録のないprovider_idの場合のみレコードを新規作成、レコードが既存の場合は該当ユーザーのデータを返すよう処理を記述


【front】
- APIをfetchする関数の作成
- Auth.jsのjwt,sessionコールバックを追加、users#createのAPIを叩き、ユーザーIDをsessionに引き渡すよう記述

【compose.yaml】
- APIのfetchでTypeError: fetch failedが発生。APIのURLにIPアドレスの指定が必要となったため、固定IPアドレスを追加しました。
参考：[Docker+Next.jsでgetdata()するとTypeError: fetch failedする問題について](https://qiita.com/tkms13/items/234d152dd9ccf49ce2f4)
## できなかったこと・やらなかったこと


## できるようになること（ユーザ目線）


## できなくなること（ユーザ目線）


## 動作確認
```ruby
# 2回目のログインをするユーザー
# ここではユーザー情報が引き渡されるのみ
back-1     | Started POST "/api/v1/users" for 172.20.0.2 at 2025-02-07 10:36:50 +0900
back-1     |   ActiveRecord::SchemaMigration Load (4.7ms)  SELECT `schema_migrations`.`version` FROM `schema_migrations` ORDER BY `schema_migrations`.`version` ASC
back-1     | Processing by Api::V1::UsersController#create as */*
back-1     |   Parameters: {"user"=>{"provider"=>"google", "providerId"=>"111451789021194114562", "name"=>"dev app"}}
back-1     |   User Load (1.4ms)  SELECT `users`.* FROM `users` WHERE `users`.`provider` = 'google' AND `users`.`provider_id` = '111451789021194114562' LIMIT 1
back-1     |   ↳ app/controllers/api/v1/users_controller.rb:4:in `create'
back-1     | Completed 200 OK in 23ms (Views: 1.9ms | ActiveRecord: 5.5ms (1 query, 0 cached) | GC: 0.0ms)
back-1     | 
back-1     | 
front-1    |  GET /api/auth/callback/google?code=4%2F0ASVgi3IhPKVaBgcPLQU1hw9jk2fas9A0XU_6TjX8yD0q9awBE8pnMdTY6_u0yQoDo6EWFg&scope=email+profile+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.email+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.profile+openid&authuser=4&prompt=none 302 in 1547ms
front-1    |  GET / 200 in 62ms
front-1    |  GET / 200 in 114ms
front-1    |  POST / 303 in 286ms
front-1    |  GET / 200 in 250ms
front-1    |  GET / 200 in 265ms
front-1    |  POST / 303 in 362ms
# 初めてのログインをするユーザー
# レコードがないため登録処理を行う
back-1     | Started POST "/api/v1/users" for 172.20.0.2 at 2025-02-07 10:37:05 +0900
back-1     | Processing by Api::V1::UsersController#create as */*
back-1     |   Parameters: {"user"=>{"provider"=>"google", "providerId"=>"105556482566660748275", "name"=>"Eri"}}
back-1     |   User Load (5.6ms)  SELECT `users`.* FROM `users` WHERE `users`.`provider` = 'google' AND `users`.`provider_id` = '105556482566660748275' LIMIT 1
back-1     |   ↳ app/controllers/api/v1/users_controller.rb:4:in `create'
back-1     |   TRANSACTION (0.8ms)  BEGIN
back-1     |   ↳ app/models/concerns/uuid_module.rb:11:in `block in generate'
back-1     |   User Exists? (6.4ms)  SELECT 1 AS one FROM `users` WHERE `users`.`id` = 'e65f4906-706c-4a3f-825e-559180261a4b' LIMIT 1
back-1     |   ↳ app/models/concerns/uuid_module.rb:11:in `block in generate'
back-1     |   User Create (7.3ms)  INSERT INTO `users` (`id`, `provider`, `provider_id`, `name`, `created_at`, `updated_at`) VALUES ('e65f4906-706c-4a3f-825e-559180261a4b', 'google', '105556482566660748275', 'Eri', '2025-02-07 10:37:05.639644', '2025-02-07 10:37:05.639644')
back-1     |   ↳ app/controllers/api/v1/users_controller.rb:6:in `create'
back-1     |   TRANSACTION (5.1ms)  COMMIT
back-1     |   ↳ app/controllers/api/v1/users_controller.rb:6:in `create'
back-1     | Completed 200 OK in 71ms (Views: 1.1ms | ActiveRecord: 25.1ms (3 queries, 0 cached) | GC: 0.0ms)
```

## その他