### PR TITLE
[Add] 【back】投稿機能の実装

### DIFF
--- a/back/app/controllers/api/v1/posts_controller.rb
+++ b/back/app/controllers/api/v1/posts_controller.rb
@@ -1,0 +1,35 @@
+class Api::V1::PostsController < ApplicationController
+  before_action :set_post, only: %i[update destroy]
+
+  def create
+    @post = Post.new(post_params)
+
+    if @post.save
+      render json: @post, status: :created
+    else
+      render json: @post.errors, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    if @post.update(post_params)
+      render json: @post, status: :ok
+    else
+      render json: @post.errors, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @post.destroy
+    render json: { message: '投稿が削除されました' }, status: :ok
+  end
+
+  private
+  def set_post
+    @post = Post.find(params[:id])
+  end
+
+  def post_params
+    params.require(:post).permit(:title, :comment, :url).merge(user_id: params[:user_id])
+  end
+end

--- a/back/app/controllers/api/v1/users_controller.rb
+++ b/back/app/controllers/api/v1/users_controller.rb
@@ -14,4 +14,8 @@ class Api::V1::UsersController < ApplicationController
       render json: { error: e.message }, status: :internal_server_error
     end
   end
+
+  def user_params
+    params.require(:user).permit(:provider, :providerId, :name)
+  end
 end

--- a/back/app/controllers/application_controller.rb
+++ b/back/app/controllers/application_controller.rb
@@ -1,2 +1,25 @@
 class ApplicationController < ActionController::API
+  # def current_user
+  #   @current_user ||= User.find(session[:user_id]) if session[:user_id]
+  # end
+  # helper_method :current_user
+
+  # def set_current_user
+  #   received_access_token = request.headers["Authorization"].split(' ').last
+
+  #   # Rails.logger.info "User ID in session: #{session[:user_id]}"
+  #   # Rails.logger.info "Received access token: #{received_access_token}"
+
+  #   if session[:user_id] && session[:access_token] == received_access_token
+  #     @current_user = User.find_by(id: session[:user_id])
+  #   else
+  #     session.delete(:access_token)
+  #     user_info = fetch_user_info_from_google(received_access_token)
+  #     @current_user = User.find_by(uid: user_info['sub']) 
+
+  #     session[:user_id] = @current_user.id
+  #     session[:access_token] = received_access_token
+  #   end
+  #   Rails.logger.info "@current_user: #{@current_user.inspect}"
+  # end
 end

--- a/back/app/models/post.rb
+++ b/back/app/models/post.rb
@@ -1,0 +1,3 @@
+class Post < ApplicationRecord
+  belongs_to :user
+end

--- a/back/app/models/post.rb
+++ b/back/app/models/post.rb
@@ -1,3 +1,7 @@
 class Post < ApplicationRecord
+  validates :title, presence: true, length: { maximum: 255 }
+  validates :comment, length: { maximum: 255 }
+  validates :url, presence: true, length: { maximum: 255 }
+
   belongs_to :user
 end

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -1,2 +1,7 @@
 class User < ApplicationRecord
+  validates :name, presence: true, length: { maximum: 30 }
+  validates :provider, presence: true, length: { maximum: 30 }
+  validates :provider_id, presence: true, length: { maximum: 255 }
+
+  has_many :posts, dependent: :destroy
 end

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :users, only: %i[create]
+      resources :posts, only: %i[create update destroy]
     end
   end
 end

--- a/back/db/migrate/20250207023157_create_posts.rb
+++ b/back/db/migrate/20250207023157_create_posts.rb
@@ -1,0 +1,12 @@
+class CreatePosts < ActiveRecord::Migration[7.2]
+  def change
+    create_table :posts, id: :string, limit: 36 do |t|
+      t.references :user, type: :string, null: false, foreign_key: true
+      t.string :title, null: false
+      t.text :comment
+      t.text :url, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -10,7 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_06_020756) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_07_023157) do
+  create_table "posts", id: { type: :string, limit: 36 }, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "user_id", null: false
+    t.string "title", null: false
+    t.text "comment"
+    t.text "url", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_posts_on_user_id"
+  end
+
   create_table "users", id: { type: :string, limit: 36 }, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "provider", null: false
     t.string "provider_id", null: false
@@ -18,4 +28,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_06_020756) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
+
+  add_foreign_key "posts", "users"
 end


### PR DESCRIPTION
## issue番号
close #8 
close #25 

## やったこと
- Postモデルを作成、create、update、destroy用のAPIを設定しました
- Userのモデルファイルのバリデーション記載を追加しました

## できなかったこと・やらなかったこと
- front側での投稿処理は別issueで対応予定 #9 

## できるようになること（ユーザ目線）


## できなくなること（ユーザ目線）


## 動作確認
ThunderClientを利用

create

[![Image from Gyazo](https://i.gyazo.com/71c2650555ed6373eff1c938198ae00e.png)](https://gyazo.com/71c2650555ed6373eff1c938198ae00e)

update

[![Image from Gyazo](https://i.gyazo.com/9a5895bae43dd4e410485c2e3cfd1e86.png)](https://gyazo.com/9a5895bae43dd4e410485c2e3cfd1e86)

destroy

[![Image from Gyazo](https://i.gyazo.com/322bba8a9dd554ee172b6d1380d41f8c.png)](https://gyazo.com/322bba8a9dd554ee172b6d1380d41f8c)

## その他