### PR TITLE
[Add] #23 ミドルウェアを利用したアクセス制限の追加と不要ページの削除

### DIFF
--- a/front/middleware.ts
+++ b/front/middleware.ts
@@ -1,34 +1,14 @@
 import { auth } from "@/auth";
-// import NextAuth from 'next-auth';
-// import { authConfig } from '@/auth.config';
-import {
-  // apiAuthPrefix,
-  publicRoutes,
-  // DEFAULT_LOGIN_REDIRECT,
-} from '@/routes';
-
-// const { auth } = NextAuth(authConfig);
-// console.log(auth)
 
 export default auth((req) => {
-  const { nextUrl } = req;
-  const isLoggedIn = !!req.auth;
+  const userId = req.nextUrl.pathname.split('/')[2];
 
-  // const isApiAuthRoute = nextUrl.pathname.startsWith(apiAuthPrefix);
-  const isPublicRoute = publicRoutes.includes(nextUrl.pathname);
-
-  // if (isApiAuthRoute) {
-  //   return null;
-  // }
-
-  // if (!isLoggedIn && !isPublicRoute) {
-  //   return Response.redirect(new URL('/', nextUrl));
-  // }
-
-  // return null;
-
+  if (!req.auth || req.auth.user.id !== userId) {
+    const newUrl = new URL("/", req.nextUrl.origin); // ルートページにリダイレクト
+    return Response.redirect(newUrl);
+  }
 });
 
 export const config = {
-  matcher: ['/((?!.+\\.[\\w]+$|_next).*)', '/', '/(api|trpc)(.*)'],
+  matcher: ['/users/:id*'], // /users/[id] とそのサブパス（/users/[id]/category など）に適用
 };

--- a/front/routes.ts
+++ b/front/routes.ts
@@ -1,7 +1,0 @@
-export const publicRoutes: string[] = ['/'];
-
-// export const authRoutes: string[] = ['/sign-up', '/sign-in'];
-
-export const apiAuthPrefix: string = '/api/auth';
-
-export const DEFAULT_LOGIN_REDIRECT: string = '/';


### PR DESCRIPTION
## issue番号
close #23 

## やったこと
- ユーザーマイページへのアクセスをユーザー本人のみに制限するよう、ミドルウェアの設定ファイルに記述を追加しました。

## できなかったこと・やらなかったこと
下記はBacklogにて対応する予定です。

- リダイレクト時のメッセージ表示 #31
- ログイン後のリダイレクト先の変更 #32

## できるようになること（ユーザ目線）


## できなくなること（ユーザ目線）
- ユーザーマイページ（/users/[id]）へのアクセスは、user_idがURLと一致するユーザーのみに制限されます

## 動作確認
ローカル環境にて以下確認済み
- 未ログインユーザーがあるユーザーのマイページurlにアクセス→ルートページにリダイレクト
- あるユーザーが別ユーザーのマイページurlにアクセス→ルートページにリダイレクト
- あるユーザーが本人のマイページurlにアクセス→マイページにアクセス可能

## その他