### PR TITLE
[Add] NewsAPIを使ったニュース記事の取得

### DIFF
--- a/front/app/page.tsx
+++ b/front/app/page.tsx
@@ -1,13 +1,14 @@
+import ArticleList from "@/components/ui/ArticleList";
 import { getNews } from "@/lib/api/news";
-import { Article } from "@/types/article";
+import { ArticleType } from "@/types/article";
 
 export default async function RootPage() {
-  const articles: Article[] = await getNews();
+  const articles: ArticleType[] = await getNews();
   return (
     <>
       <div className="flex flex-col items-center justify-center h-screen">
         <h1 className="text-4xl font-bold my-10">ここはRoot Page!</h1>
-        
+        <ArticleList articles={articles} />
       </div>
     </>
   );

--- a/front/app/page.tsx
+++ b/front/app/page.tsx
@@ -1,12 +1,13 @@
-import SignInButton from "@/components/ui/SignInButton";
+import { getNews } from "@/lib/api/news";
+import { Article } from "@/types/article";
 
 export default async function RootPage() {
-
+  const articles: Article[] = await getNews();
   return (
     <>
       <div className="flex flex-col items-center justify-center h-screen">
         <h1 className="text-4xl font-bold my-10">ここはRoot Page!</h1>
-        <SignInButton />
+        
       </div>
     </>
   );

--- a/front/app/page.tsx
+++ b/front/app/page.tsx
@@ -1,9 +1,13 @@
 import ArticleList from "@/components/ui/ArticleList";
 import { getNews } from "@/lib/api/news";
+import { getQiitaArticles } from "@/lib/api/qiita";
 import { ArticleType } from "@/types/article";
+import { QiitaArticleType } from "@/types/qiita";
 
 export default async function RootPage() {
   const articles: ArticleType[] = await getNews();
+  const qiitaArticles: QiitaArticleType[] = await getQiitaArticles();
+  console.log(qiitaArticles)
   return (
     <>
       <div className="flex flex-col items-center justify-center h-screen">

--- a/front/components/ModalController.tsx
+++ b/front/components/ModalController.tsx
@@ -9,12 +9,14 @@ import { useState } from "react";
 import Modal from "./ui/Modal";
 import PostForm from "./ui/PostForm";
 import { Post } from "@/types/post";
+import { ArticleType } from "@/types/article";
 
 type ModalControllerProps = {
   post?: Post;
+  article?: ArticleType;
 };
 
-export default function ModalController({ post }: ModalControllerProps) {
+export default function ModalController({ post, article }: ModalControllerProps) {
   const [isOpen, setIsOpen] = useState(false);
 
   const openModal = () => {
@@ -38,7 +40,7 @@ export default function ModalController({ post }: ModalControllerProps) {
         {` ${post ? "Edit" : "Create Post"}`}
       </button>
       <Modal isOpen={isOpen}>
-        <PostForm post={post}/>
+        <PostForm post={post} article={article}/>
         <button
           onClick={closeModal}
           className="w-full px-4 py-2 bg-white text-red-500 rounded-md hover:text-red-800 transition-colors my-4"

--- a/front/components/ui/Article.tsx
+++ b/front/components/ui/Article.tsx
@@ -35,7 +35,7 @@ export default async function Article({ article }: Props) {
       </Link>
       {session && (
         <div className="flex mt-4 justify-end">
-          <ModalController />
+          <ModalController article={article}/>
         </div>
       )}
     </div>

--- a/front/components/ui/Article.tsx
+++ b/front/components/ui/Article.tsx
@@ -1,0 +1,43 @@
+import { auth } from "@/auth";
+import { ArticleType } from "@/types/article";
+import Link from "next/link";
+import ModalController from "../ModalController";
+
+type Props = {
+  article: ArticleType;
+};
+export default async function Article({ article }: Props) {
+  const session = await auth();
+
+  return (
+    <div className="rounded-lg shadow-md p-4 my-4 flex flex-col">
+      <Link
+        href={article.url}
+        target="_blank"
+        className="p-4 rounded-lg hover:bg-stone-100"
+      >
+        <div className="flex items-start space-x-4">
+          {article.urlToImage && (
+            <img
+              className="w-30 h-24 object-cover rounded-md"
+              height="100"
+              key={article.title}
+              src={article.urlToImage}
+              alt={`${article.title} image`}
+              width="120"
+            />
+          )}
+          <div className="space-y-2">
+            <h2 className="text-xl font-bold ">{article.title}</h2>
+            <p className="text-gray-700">{article.description}</p>
+          </div>
+        </div>
+      </Link>
+      {session && (
+        <div className="flex mt-4 justify-end">
+          <ModalController />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/front/components/ui/ArticleList.tsx
+++ b/front/components/ui/ArticleList.tsx
@@ -1,0 +1,21 @@
+import { ArticleType } from "@/types/article";
+import Article from "./Article";
+
+type Props = {
+  articles: ArticleType[];
+};
+
+export default function ArticleList({ articles }: Props) {
+  return (
+    <>
+      <div className="mx-auto w-3/4 md:w-3/5 mt-10">
+        <h1 className="text-2xl font-bold mb-4">News</h1>
+        <div className="w-full">
+          {articles.map((article: ArticleType) => (
+            <Article key={article.title} article={article} />
+          ))}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/front/components/ui/PostForm.tsx
+++ b/front/components/ui/PostForm.tsx
@@ -1,13 +1,15 @@
 "use client";
 
 import { createAction, updateAction } from "@/lib/actions/post";
+import { ArticleType } from "@/types/article";
 import { Post } from "@/types/post";
 
 type PostFormProps = {
   post?: Post;
+  article?: ArticleType;
 }
 
-export default function PostForm({post}: PostFormProps) {
+export default function PostForm({post, article}: PostFormProps) {
   const updatePostWithId = updateAction.bind(null, post?.id);
   return (
     <>
@@ -24,7 +26,7 @@ export default function PostForm({post}: PostFormProps) {
             <input
               type="url"
               name="url"
-              defaultValue={post?.url}
+              defaultValue={post?.url || article?.url}
               className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-300 focus:ring focus:ring-blue-200 focus:ring-opacity-50"
             />
           </div>

--- a/front/lib/api/news.ts
+++ b/front/lib/api/news.ts
@@ -1,0 +1,13 @@
+export const getNews = async () => {
+  const API = process.env.NEWS_API_KEY;
+  const response = await fetch(`https://newsapi.org/v2/top-headlines?country=us&pageSize=5&apiKey=${API}`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    cache: 'no-cache',
+  });
+  const json = await response.json();
+  const articles = json?.articles;
+  return articles
+}

--- a/front/lib/api/qiita.ts
+++ b/front/lib/api/qiita.ts
@@ -1,0 +1,24 @@
+import { QiitaArticleType, QiitaResponseType } from "@/types/qiita";
+
+export const getQiitaArticles = async () => {
+  const API = process.env.QIITA_API_KEY;
+  const response = await fetch(
+    `https://qiita.com/api/v2/items?page=1&per_page=10&query=stocks:>20`,
+    {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+        "Authorization": `Bearer ${API}`,
+      },
+      cache: "no-cache",
+    }
+  );
+  const json: QiitaResponseType = await response.json();
+  const articles: QiitaArticleType[] = json.items.map(article => ({
+    title: article.title,
+    url: article.url
+  }));
+
+  return articles;
+};

--- a/front/lib/api/qiita.ts
+++ b/front/lib/api/qiita.ts
@@ -1,4 +1,4 @@
-import { QiitaArticleType, QiitaResponseType } from "@/types/qiita";
+import { QiitaArticleType } from "@/types/qiita";
 
 export const getQiitaArticles = async () => {
   const API = process.env.QIITA_API_KEY;
@@ -14,8 +14,8 @@ export const getQiitaArticles = async () => {
       cache: "no-cache",
     }
   );
-  const json: QiitaResponseType = await response.json();
-  const articles: QiitaArticleType[] = json.items.map(article => ({
+  const json = await response.json();
+  const articles = json.map((article: QiitaArticleType) => ({
     title: article.title,
     url: article.url
   }));

--- a/front/types/article.ts
+++ b/front/types/article.ts
@@ -1,6 +1,7 @@
-export interface Article {
+export interface ArticleType {
   author: string;
   title: string;
+  description: string;
   publishedAt: string;
   url: string;
   urlToImage: string;

--- a/front/types/article.ts
+++ b/front/types/article.ts
@@ -1,0 +1,7 @@
+export interface Article {
+  author: string;
+  title: string;
+  publishedAt: string;
+  url: string;
+  urlToImage: string;
+}

--- a/front/types/qiita.ts
+++ b/front/types/qiita.ts
@@ -1,10 +1,3 @@
-export interface QiitaResponseType {
-  items: {
-    title: string;
-    url: string;
-  }[];
-}
-
 export interface QiitaArticleType {
   title: string;
   url: string;

--- a/front/types/qiita.ts
+++ b/front/types/qiita.ts
@@ -1,0 +1,11 @@
+export interface QiitaResponseType {
+  items: {
+    title: string;
+    url: string;
+  }[];
+}
+
+export interface QiitaArticleType {
+  title: string;
+  url: string;
+}


### PR DESCRIPTION
## issue番号
close #12 
close #15 
#13 
## やったこと
- [NewsAPI](https://newsapi.org/)のAPIキーを取得、トップ画面でTop-Headlineの記事を取得し表示するよう実装しました
- ログイン済みの場合は、記事の下部にある「Create Post」を押すと新規投稿モーダルが開きます
- 記事から新規投稿モーダルを開いた際は、該当記事のurlがデフォルト値で設定されます
- Qiita APIからの記事取得用APIも設定済みです

## できなかったこと・やらなかったこと
Qiita APIからのレスポンスはOGP画像情報が含まれていなかったため、URLから別途取得する必要あり。
別issue#37 にてスクレイパーを用いて実装する際、合わせて実装予定


## できるようになること（ユーザ目線）
- トップページにアクセスすると、NewsAPIから取得した最新記事一覧が閲覧できます
- ログイン済みの場合、記事カード上の「Create Post」を押すとそのまま該当記事を投稿することができ、マイページで確認できます。

## できなくなること（ユーザ目線）


## 動作確認
ローカル環境にて動作確認済み

## その他