### PR TITLE
[Add] スクレイパーの導入

### DIFF
--- a/front/app/page.tsx
+++ b/front/app/page.tsx
@@ -10,8 +10,7 @@ export default async function RootPage() {
   console.log(qiitaArticles)
   return (
     <>
-      <div className="flex flex-col items-center justify-center h-screen">
-        <h1 className="text-4xl font-bold my-10">ここはRoot Page!</h1>
+      <div className="flex flex-col items-center justify-center mt-10">
         <ArticleList articles={articles} />
       </div>
     </>

--- a/front/app/page.tsx
+++ b/front/app/page.tsx
@@ -2,16 +2,15 @@ import ArticleList from "@/components/ui/ArticleList";
 import { getNews } from "@/lib/api/news";
 import { getQiitaArticles } from "@/lib/api/qiita";
 import { ArticleType } from "@/types/article";
-import { QiitaArticleType } from "@/types/qiita";
 
 export default async function RootPage() {
   const articles: ArticleType[] = await getNews();
-  const qiitaArticles: QiitaArticleType[] = await getQiitaArticles();
-  console.log(qiitaArticles)
+  const qiitaUrls: ArticleType[] = await getQiitaArticles();
   return (
     <>
       <div className="flex flex-col items-center justify-center mt-10">
         <ArticleList articles={articles} />
+        <ArticleList articles={qiitaUrls} />
       </div>
     </>
   );

--- a/front/app/users/[id]/page.tsx
+++ b/front/app/users/[id]/page.tsx
@@ -18,7 +18,7 @@ export default async function MyPage() {
   return (
     <>
       <div className="flex flex-col items-center justify-center mt-20">
-        <h1 className="text-4xl font-bold my-10">ここはMyPage!</h1>
+        <h1 className="text-4xl font-bold my-10">MyPage</h1>
         <ModalController categories={categories}/>
         <PostCardList posts={posts}/>
       </div>

--- a/front/components/ModalController.tsx
+++ b/front/components/ModalController.tsx
@@ -9,15 +9,14 @@ import { useState } from "react";
 import Modal from "./ui/Modal";
 import PostForm from "./ui/PostForm";
 import { Post } from "@/types/post";
-import { ArticleType } from "@/types/article";
 
 type ModalControllerProps = {
   post?: Post;
-  article?: ArticleType;
+  url?: string;
   categories: string[]
 };
 
-export default function ModalController({ post, article, categories }: ModalControllerProps) {
+export default function ModalController({ post, url, categories }: ModalControllerProps) {
   const [isOpen, setIsOpen] = useState(false);
 
   const openModal = () => {
@@ -41,7 +40,7 @@ export default function ModalController({ post, article, categories }: ModalCont
         {` ${post ? "Edit" : "Create Post"}`}
       </button>
       <Modal isOpen={isOpen}>
-        <PostForm post={post} article={article} categories={categories} closeModal={closeModal} />
+        <PostForm post={post} url={url} categories={categories} closeModal={closeModal} />
         <button
           onClick={closeModal}
           className="w-full px-4 py-2 bg-white text-red-500 rounded-md hover:text-red-800 transition-colors my-4"

--- a/front/components/layouts/Header.tsx
+++ b/front/components/layouts/Header.tsx
@@ -8,6 +8,14 @@ export default async function Header() {
 
   return (
     <header className="flex justify-center border-b px-10 top-0 left-0 z-50 bg-white fixed w-full">
+      <div className="flex items-center justify-start w-full h-16 gap-6">
+      <Link
+            href="/"
+            className="font-bold px-4 py-2 bg-white rounded-md hover:bg-slate-600 hover:text-white transition-colors"
+          >
+            Note Stacker
+          </Link>
+      </div>
       <div className="flex items-center justify-end w-full h-16 gap-6">
         {/* {session && <p className="font-bold">{session.user.name} さん</p>} */}
         {session && (

--- a/front/components/ui/Article.tsx
+++ b/front/components/ui/Article.tsx
@@ -1,44 +1,51 @@
 import { auth } from "@/auth";
-import { ArticleType } from "@/types/article";
 import Link from "next/link";
 import ModalController from "../ModalController";
 import { getCategoriesByUserId } from "@/lib/api/category";
+import { getOgp } from "@/lib/ogp";
 
 type Props = {
-  article: ArticleType;
+  url: string;
 };
-export default async function Article({ article }: Props) {
+export default async function Article({ url }: Props) {
   const session = await auth();
   const id = session?.user.id;
   const categories: string[] = await getCategoriesByUserId(id);
+  const ogp = await getOgp(`${url}`);
 
   return (
     <div className="rounded-lg shadow-md p-4 my-4 flex flex-col">
       <Link
-        href={article.url}
+        href={url}
         target="_blank"
         className="p-4 rounded-lg hover:bg-stone-100"
       >
         <div className="flex flex-col md:flex-row md:items-start md:space-x-4 space-y-2">
-          {article.urlToImage && (
-            <img
-              className="w-30 h-24 object-cover rounded-md"
-              height="100"
-              key={article.title}
-              src={article.urlToImage}
-              alt={`${article.title} image`}
-              width="120"
-            />
-          )}
+          <img
+            alt="Article thumbnail"
+            className="w-30 h-24 object-cover rounded-md"
+            height="100"
+            src={
+              (ogp?.ogImage &&
+                ogp?.ogImage.length > 0 &&
+                ogp?.ogImage[0]?.url) ||
+              "/placeholder.png"
+            }
+            style={{
+              aspectRatio: "1/1",
+              objectFit: "cover",
+            }}
+            width="120"
+          />
           <div className="space-y-2">
-            <h2 className="text-xl font-bold ">{article.title}</h2>
-            <p className="text-gray-700">{article.description}</p>
+            <h2 className="text-xl font-bold ">{ogp?.ogTitle}</h2>
+            {/* <p className="text-gray-700">{article.description}</p> */}
           </div>
         </div>
       </Link>
       {session && (
         <div className="flex mt-4 justify-end">
-          <ModalController article={article} categories={categories} />
+          <ModalController url={url} categories={categories} />
         </div>
       )}
     </div>

--- a/front/components/ui/Article.tsx
+++ b/front/components/ui/Article.tsx
@@ -2,12 +2,15 @@ import { auth } from "@/auth";
 import { ArticleType } from "@/types/article";
 import Link from "next/link";
 import ModalController from "../ModalController";
+import { getCategoriesByUserId } from "@/lib/api/category";
 
 type Props = {
   article: ArticleType;
 };
 export default async function Article({ article }: Props) {
   const session = await auth();
+  const id = session?.user.id;
+  const categories: string[] = await getCategoriesByUserId(id);
 
   return (
     <div className="rounded-lg shadow-md p-4 my-4 flex flex-col">
@@ -35,7 +38,7 @@ export default async function Article({ article }: Props) {
       </Link>
       {session && (
         <div className="flex mt-4 justify-end">
-          <ModalController article={article} categories={[]}/>
+          <ModalController article={article} categories={categories} />
         </div>
       )}
     </div>

--- a/front/components/ui/Article.tsx
+++ b/front/components/ui/Article.tsx
@@ -19,7 +19,7 @@ export default async function Article({ article }: Props) {
         target="_blank"
         className="p-4 rounded-lg hover:bg-stone-100"
       >
-        <div className="flex items-start space-x-4">
+        <div className="flex flex-col md:flex-row md:items-start md:space-x-4 space-y-2">
           {article.urlToImage && (
             <img
               className="w-30 h-24 object-cover rounded-md"

--- a/front/components/ui/ArticleList.tsx
+++ b/front/components/ui/ArticleList.tsx
@@ -12,7 +12,7 @@ export default function ArticleList({ articles }: Props) {
         <h1 className="text-2xl font-bold mb-4">News</h1>
         <div className="w-full">
           {articles.map((article: ArticleType) => (
-            <Article key={article.title} article={article} />
+            <Article key={article.url} url={article.url} />
           ))}
         </div>
       </div>

--- a/front/components/ui/PostCard.tsx
+++ b/front/components/ui/PostCard.tsx
@@ -4,6 +4,7 @@ import DeleteBtn from "./DeleteBtn";
 import ModalController from "../ModalController";
 import { auth } from "@/auth";
 import { getCategoriesByUserId } from "@/lib/api/category";
+import { getOgp } from "@/lib/ogp";
 
 type Props = {
   post: Post;
@@ -13,6 +14,7 @@ export default async function PostCard({ post }: Props) {
   const session = await auth();
   const id = session?.user.id;
   const categories: string[] = await getCategoriesByUserId(id);
+  const ogp = await getOgp(`${post.url}`);
 
   return (
     <div className="rounded-lg shadow-md p-4 my-4 flex flex-col">
@@ -26,18 +28,15 @@ export default async function PostCard({ post }: Props) {
             alt="Article thumbnail"
             className="w-30 h-24 object-cover rounded-md"
             height="100"
-            src="/placeholder.png"
-            // src={post.article.ogImage || "/placeholder.svg"}
-            // style={{
-            // aspectRatio: "1/1",
-            //   objectFit: "cover",
-            // }}
+            src={(ogp?.ogImage && ogp?.ogImage.length > 0 && ogp?.ogImage[0]?.url) || "/placeholder.png"}
+            style={{
+            aspectRatio: "1/1",
+              objectFit: "cover",
+            }}
             width="120"
           />
           <div className="space-y-2">
-            {/* urlから取得した記事タイトルを反映予定 */}
-            <h2 className="text-xl font-bold ">タイトル</h2>
-            <p className="text-gray-700">{/* {post.article.description} */}</p>
+            <h2 className="text-xl font-bold ">{ogp?.ogTitle ?? "No Title"}</h2>
           </div>
         </div>
         <div className="flex flex-wrap gap-2 my-2">

--- a/front/components/ui/PostCard.tsx
+++ b/front/components/ui/PostCard.tsx
@@ -23,7 +23,7 @@ export default async function PostCard({ post }: Props) {
         target="_blank"
         className="p-4 rounded-lg hover:bg-stone-100"
       >
-        <div className="flex items-start space-x-4">
+        <div className="flex flex-col md:flex-row md:items-start md:space-x-4 space-y-2">
           <img
             alt="Article thumbnail"
             className="w-30 h-24 object-cover rounded-md"

--- a/front/components/ui/PostForm.tsx
+++ b/front/components/ui/PostForm.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { createAction, updateAction } from "@/lib/actions/post";
-import { ArticleType } from "@/types/article";
 import { Post } from "@/types/post";
 import { useRouter } from "next/navigation";
 
@@ -9,14 +8,14 @@ import { useState } from "react";
 
 type PostFormProps = {
   post?: Post;
-  article?: ArticleType;
+  url?: string;
   categories: string[];
   closeModal: () => void;
 };
 
 export default function PostForm({
   post,
-  article,
+  url,
   categories,
   closeModal,
 }: PostFormProps) {
@@ -105,7 +104,7 @@ export default function PostForm({
             <input
               type="url"
               name="url"
-              defaultValue={post?.url || article?.url}
+              defaultValue={post?.url || url}
               className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-300 focus:ring focus:ring-blue-200 focus:ring-opacity-50"
             />
           </div>

--- a/front/lib/api/news.ts
+++ b/front/lib/api/news.ts
@@ -1,13 +1,21 @@
+import { ArticleType } from "@/types/article";
+
 export const getNews = async () => {
   const API = process.env.NEWS_API_KEY;
-  const response = await fetch(`https://newsapi.org/v2/top-headlines?country=us&pageSize=5&apiKey=${API}`, {
-    method: 'GET',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    cache: 'no-cache',
-  });
+  const response = await fetch(
+    `https://newsapi.org/v2/top-headlines?country=us&pageSize=5&apiKey=${API}`,
+    {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      cache: "no-cache",
+    }
+  );
   const json = await response.json();
-  const articles = json?.articles;
-  return articles
-}
+  const articles = json.articles.map((article: ArticleType) => ({
+    url: article.url,
+  }));
+
+  return articles;
+};

--- a/front/lib/api/qiita.ts
+++ b/front/lib/api/qiita.ts
@@ -1,4 +1,4 @@
-import { QiitaArticleType } from "@/types/qiita";
+import { ArticleType } from "@/types/article";
 
 export const getQiitaArticles = async () => {
   const API = process.env.QIITA_API_KEY;
@@ -15,8 +15,7 @@ export const getQiitaArticles = async () => {
     }
   );
   const json = await response.json();
-  const articles = json.map((article: QiitaArticleType) => ({
-    title: article.title,
+  const articles = json.map((article: ArticleType) => ({
     url: article.url
   }));
 

--- a/front/lib/ogp.ts
+++ b/front/lib/ogp.ts
@@ -1,0 +1,11 @@
+import ogs from "open-graph-scraper";
+
+export async function getOgp(url: string) {
+  try {
+    const { result } = await ogs({ url });
+    return result;
+  } catch (error) {
+    console.error("Error fetching OGP:", error);
+    return null;
+  }
+}

--- a/front/package.json
+++ b/front/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "next": "15.1.6",
     "next-auth": "^5.0.0-beta.25",
+    "open-graph-scraper": "^6.9.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/front/types/article.ts
+++ b/front/types/article.ts
@@ -1,8 +1,3 @@
 export interface ArticleType {
-  author: string;
-  title: string;
-  description: string;
-  publishedAt: string;
   url: string;
-  urlToImage: string;
 }

--- a/front/types/qiita.ts
+++ b/front/types/qiita.ts
@@ -1,4 +1,0 @@
-export interface QiitaArticleType {
-  title: string;
-  url: string;
-}

--- a/front/yarn.lock
+++ b/front/yarn.lock
@@ -698,6 +698,11 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.3.0.tgz#f6e14a97858d327252200242d4ccfe522c445522"
   integrity sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==
 
+boolbase@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
+  integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -776,6 +781,40 @@ chalk@^4.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chardet@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-2.1.0.tgz#1007f441a1ae9f9199a4a67f6e978fb0aa9aa3fe"
+  integrity sha512-bNFETTG/pM5ryzQ9Ad0lJOTa6HWD/YsScAR3EnCPZRPlQh77JocYktSHOUHelyhm8IARL+o4c4F1bP5KVOjiRA==
+
+cheerio-select@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cheerio-select/-/cheerio-select-2.1.0.tgz#4d8673286b8126ca2a8e42740d5e3c4884ae21b4"
+  integrity sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==
+  dependencies:
+    boolbase "^1.0.0"
+    css-select "^5.1.0"
+    css-what "^6.1.0"
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
+    domutils "^3.0.1"
+
+cheerio@^1.0.0-rc.12:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0.tgz#1ede4895a82f26e8af71009f961a9b8cb60d6a81"
+  integrity sha512-quS9HgjQpdaXOvsZz82Oz7uxtXiy6UIsIQcpBj7HRw2M63Skasm9qlDocAM7jNuaxdhpPU7c4kJN+gA5MCu4ww==
+  dependencies:
+    cheerio-select "^2.1.0"
+    dom-serializer "^2.0.0"
+    domhandler "^5.0.3"
+    domutils "^3.1.0"
+    encoding-sniffer "^0.2.0"
+    htmlparser2 "^9.1.0"
+    parse5 "^7.1.2"
+    parse5-htmlparser2-tree-adapter "^7.0.0"
+    parse5-parser-stream "^7.1.2"
+    undici "^6.19.5"
+    whatwg-mimetype "^4.0.0"
+
 chokidar@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.6.0.tgz#197c6cc669ef2a8dc5e7b4d97ee4e092c3eb0d5b"
@@ -847,6 +886,22 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.6:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
+
+css-select@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-5.1.0.tgz#b8ebd6554c3637ccc76688804ad3f6a6fdaea8a6"
+  integrity sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==
+  dependencies:
+    boolbase "^1.0.0"
+    css-what "^6.1.0"
+    domhandler "^5.0.2"
+    domutils "^3.0.1"
+    nth-check "^2.0.1"
+
+css-what@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-6.1.0.tgz#fb5effcf76f1ddea2c81bdfaa4de44e79bac70f4"
+  integrity sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==
 
 cssesc@^3.0.0:
   version "3.0.0"
@@ -949,6 +1004,36 @@ doctrine@^2.1.0:
   dependencies:
     esutils "^2.0.2"
 
+dom-serializer@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-2.0.0.tgz#e41b802e1eedf9f6cae183ce5e622d789d7d8e53"
+  integrity sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==
+  dependencies:
+    domelementtype "^2.3.0"
+    domhandler "^5.0.2"
+    entities "^4.2.0"
+
+domelementtype@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.3.0.tgz#5c45e8e869952626331d7aab326d01daf65d589d"
+  integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
+
+domhandler@^5.0.2, domhandler@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-5.0.3.tgz#cc385f7f751f1d1fc650c21374804254538c7d31"
+  integrity sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==
+  dependencies:
+    domelementtype "^2.3.0"
+
+domutils@^3.0.1, domutils@^3.1.0:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-3.2.2.tgz#edbfe2b668b0c1d97c24baf0f1062b132221bc78"
+  integrity sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==
+  dependencies:
+    dom-serializer "^2.0.0"
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
+
 dunder-proto@^1.0.0, dunder-proto@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/dunder-proto/-/dunder-proto-1.0.1.tgz#d7ae667e1dc83482f8b70fd0f6eefc50da30f58a"
@@ -973,6 +1058,14 @@ emoji-regex@^9.2.2:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
   integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
 
+encoding-sniffer@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/encoding-sniffer/-/encoding-sniffer-0.2.0.tgz#799569d66d443babe82af18c9f403498365ef1d5"
+  integrity sha512-ju7Wq1kg04I3HtiYIOrUrdfdDvkyO9s5XM8QAj/bN61Yo/Vb4vgJxy5vi4Yxk01gWHbrofpPtpxM8bKger9jhg==
+  dependencies:
+    iconv-lite "^0.6.3"
+    whatwg-encoding "^3.1.1"
+
 enhanced-resolve@^5.15.0:
   version "5.18.0"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.18.0.tgz#91eb1db193896b9801251eeff1c6980278b1e404"
@@ -980,6 +1073,11 @@ enhanced-resolve@^5.15.0:
   dependencies:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
+
+entities@^4.2.0, entities@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
+  integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
 
 es-abstract@^1.17.5, es-abstract@^1.23.2, es-abstract@^1.23.3, es-abstract@^1.23.5, es-abstract@^1.23.6, es-abstract@^1.23.9:
   version "1.23.9"
@@ -1578,6 +1676,23 @@ hasown@^2.0.0, hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
+htmlparser2@^9.1.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-9.1.0.tgz#cdb498d8a75a51f739b61d3f718136c369bc8c23"
+  integrity sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==
+  dependencies:
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
+    domutils "^3.1.0"
+    entities "^4.5.0"
+
+iconv-lite@0.6.3, iconv-lite@^0.6.3:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
+  integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
+
 ignore@^5.2.0, ignore@^5.3.1:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.2.tgz#3cd40e729f3643fd87cb04e50bf0eb722bc596f5"
@@ -2053,6 +2168,13 @@ normalize-path@^3.0.0, normalize-path@~3.0.0:
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
+nth-check@^2.0.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.1.1.tgz#c9eab428effce36cd6b92c924bdb000ef1f1ed1d"
+  integrity sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==
+  dependencies:
+    boolbase "^1.0.0"
+
 oauth4webapi@^3.0.0:
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/oauth4webapi/-/oauth4webapi-3.1.4.tgz#50695385cea8e7a43f3e2e23bc33ea27faece4a7"
@@ -2128,6 +2250,16 @@ object.values@^1.1.6, object.values@^1.2.0, object.values@^1.2.1:
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
 
+open-graph-scraper@^6.9.0:
+  version "6.9.0"
+  resolved "https://registry.yarnpkg.com/open-graph-scraper/-/open-graph-scraper-6.9.0.tgz#e3121144b99fbef1f05b944aacabe6f149e16be4"
+  integrity sha512-1KoV5v6GT0/MqlryrVGQROhEAD4u8wC3VjYOxsnhj3mWeGJ6N6nF/rbrcZREFr+kiYm9I5LMrzdK9t9hBMbL2Q==
+  dependencies:
+    chardet "^2.0.0"
+    cheerio "^1.0.0-rc.12"
+    iconv-lite "^0.6.3"
+    undici "^6.21.0"
+
 optionator@^0.9.3:
   version "0.9.4"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.9.4.tgz#7ea1c1a5d91d764fb282139c88fe11e182a3a734"
@@ -2174,6 +2306,28 @@ parent-module@^1.0.0:
   integrity sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
   dependencies:
     callsites "^3.0.0"
+
+parse5-htmlparser2-tree-adapter@^7.0.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz#b5a806548ed893a43e24ccb42fbb78069311e81b"
+  integrity sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==
+  dependencies:
+    domhandler "^5.0.3"
+    parse5 "^7.0.0"
+
+parse5-parser-stream@^7.1.2:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz#d7c20eadc37968d272e2c02660fff92dd27e60e1"
+  integrity sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==
+  dependencies:
+    parse5 "^7.0.0"
+
+parse5@^7.0.0, parse5@^7.1.2:
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-7.2.1.tgz#8928f55915e6125f430cc44309765bf17556a33a"
+  integrity sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==
+  dependencies:
+    entities "^4.5.0"
 
 path-exists@^4.0.0:
   version "4.0.0"
@@ -2450,6 +2604,11 @@ safe-regex-test@^1.0.3, safe-regex-test@^1.1.0:
     call-bound "^1.0.2"
     es-errors "^1.3.0"
     is-regex "^1.2.1"
+
+"safer-buffer@>= 2.1.2 < 3.0.0":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
+  integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
 scheduler@^0.25.0:
   version "0.25.0"
@@ -2900,6 +3059,11 @@ undici-types@~6.19.2:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.19.8.tgz#35111c9d1437ab83a7cdc0abae2f26d88eda0a02"
   integrity sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==
 
+undici@^6.19.5, undici@^6.21.0:
+  version "6.21.1"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-6.21.1.tgz#336025a14162e6837e44ad7b819b35b6c6af0e05"
+  integrity sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==
+
 uri-js@^4.2.2:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.1.tgz#9b1a52595225859e55f669d928f88c6c57f2a77e"
@@ -2911,6 +3075,18 @@ util-deprecate@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
+
+whatwg-encoding@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz#d0f4ef769905d426e1688f3e34381a99b60b76e5"
+  integrity sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==
+  dependencies:
+    iconv-lite "0.6.3"
+
+whatwg-mimetype@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz#bc1bf94a985dc50388d54a9258ac405c3ca2fc0a"
+  integrity sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==
 
 which-boxed-primitive@^1.1.0, which-boxed-primitive@^1.1.1:
   version "1.1.1"


### PR DESCRIPTION
## issue番号
close #37 
close #13 

## やったこと
- ライブラリopen-graph-scraperをインストールし、URLを元にOGP情報を取得できるよう実装しました
- NewsAPI、QiitaAPIでは記事のURLを取得し、タイトルやサムネイル画像はスクレイパーで取得するよう統一しました

## できなかったこと・やらなかったこと


## できるようになること（ユーザ目線）
- ルートページで、NewsAPIの記事一覧、Qiita記事一覧を閲覧できます
- マイページで、投稿したURLのタイトルとOGP画像が表示されます

ルートページのQiita記事カード
[![Image from Gyazo](https://i.gyazo.com/7bcb39bbfc8cf8906571003a01886f8f.jpg)](https://gyazo.com/7bcb39bbfc8cf8906571003a01886f8f)

## できなくなること（ユーザ目線）


## 動作確認
ローカル環境にて動作確認済み

## その他