### PR TITLE
[Add] カテゴリによる絞り込み機能

### DIFF
--- a/front/app/page.tsx
+++ b/front/app/page.tsx
@@ -9,8 +9,8 @@ export default async function RootPage() {
   return (
     <>
       <div className="flex flex-col items-center justify-center mt-10">
-        <ArticleList articles={articles} />
-        <ArticleList articles={qiitaUrls} />
+        <ArticleList articles={articles} title="TechCrunch" />
+        <ArticleList articles={qiitaUrls} title="Qiita" />
       </div>
     </>
   );

--- a/front/app/users/[id]/page.tsx
+++ b/front/app/users/[id]/page.tsx
@@ -1,26 +1,46 @@
 import { auth } from "@/auth";
+import Sidebar from "@/components/layouts/Sidebar";
 import ModalController from "@/components/ModalController";
 import PostCardList from "@/components/ui/PostCardList";
 import { getCategoriesByUserId } from "@/lib/api/category";
 import { getPostsByUserId } from "@/lib/api/user";
 import { Post } from "@/types/post";
 
-// type Props = {
-//   params: Promise<{ id: string }>;
-// };
+function filterPosts(posts: Post[], category: string): Post[] {
+  if (category === "all") {
+    return posts;
+  }
+  return posts.filter((post) =>
+    post.categories.some((cat) => cat.name === category)
+  );
+}
 
-export default async function MyPage() {
-  // const {id} = await params;
+export default async function MyPage({
+  searchParams,
+}: {
+  searchParams: { [key: string]: string | string[] | undefined };
+}) {
+  const searchWord = await searchParams;
   const session = await auth();
   const id = session?.user.id;
   const posts: Post[] = await getPostsByUserId(id);
   const categories: string[] = await getCategoriesByUserId(id);
+  const selectedCategory =
+    typeof searchWord.category === "string" ? searchWord.category : "all";
+  const filteredPosts = filterPosts(posts, selectedCategory);
   return (
     <>
-      <div className="flex flex-col items-center justify-center mt-20">
-        <h1 className="text-4xl font-bold my-10">MyPage</h1>
-        <ModalController categories={categories}/>
-        <PostCardList posts={posts}/>
+      <div className="flex min-h-screen">
+        <Sidebar
+          id={id}
+          categories={categories}
+          selectedCategory={selectedCategory}
+        />
+        <main className="flex flex-col w-full items-center justify-center mt-20 lg:ml-64">
+          <h1 className="text-4xl font-bold my-10">MyPage</h1>
+          <ModalController categories={categories} />
+          <PostCardList posts={filteredPosts} />
+        </main>
       </div>
     </>
   );

--- a/front/app/users/[id]/page.tsx
+++ b/front/app/users/[id]/page.tsx
@@ -6,6 +6,10 @@ import { getCategoriesByUserId } from "@/lib/api/category";
 import { getPostsByUserId } from "@/lib/api/user";
 import { Post } from "@/types/post";
 
+type Props = {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+};
+
 function filterPosts(posts: Post[], category: string): Post[] {
   if (category === "all") {
     return posts;
@@ -15,11 +19,7 @@ function filterPosts(posts: Post[], category: string): Post[] {
   );
 }
 
-export default async function MyPage({
-  searchParams,
-}: {
-  searchParams: { [key: string]: string | string[] | undefined };
-}) {
+export default async function MyPage({ searchParams }: Props) {
   const searchWord = await searchParams;
   const session = await auth();
   const id = session?.user.id;

--- a/front/components/layouts/Sidebar.tsx
+++ b/front/components/layouts/Sidebar.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+
+type Props = {
+  categories: string[];
+  selectedCategory: string;
+  id: string;
+};
+
+export default function Sidebar({ id, categories, selectedCategory }: Props) {
+  const [isOpen, setIsOpen] = useState(false);
+  const toggleSidebar = () => setIsOpen(!isOpen);
+  return (
+    <>
+      <button
+        className="lg:hidden fixed top-4 left-4 z-20 bg-white p-2 rounded-md shadow-md mt-20"
+        onClick={toggleSidebar}
+        aria-label="Toggle sidebar"
+      >
+        {isOpen ? "X" : "Category"}
+      </button>
+      <aside
+        className={`${
+          isOpen ? "translate-x-0" : "-translate-x-full"
+        } lg:translate-x-0 fixed top-0 left-0 z-10 h-full w-64 bg-slate-50 shadow-md transition-transform duration-300 ease-in-out`}
+      >
+        <nav className="p-4 lg:p-10">
+          <h2 className="text-xl font-semibold mb-4 lg:mt-20 mt-40">
+            Categories
+          </h2>
+          <ul>
+            <li className="mb-2">
+              <Link
+                href={`/users/${id}?category=${encodeURIComponent("all")}`}
+                className={`${
+                  encodeURIComponent(selectedCategory) ===
+                  encodeURIComponent("all")
+                    ? "text-blue-600 font-semibold"
+                    : "text-gray-600"
+                } hover:text-gray-900`}
+              >
+                All
+              </Link>
+            </li>
+            {categories.map((category) => (
+              <li key={category} className="mb-2">
+                <Link
+                  href={`/users/${id}?category=${encodeURIComponent(category)}`}
+                  className={`${
+                    encodeURIComponent(selectedCategory) ===
+                    encodeURIComponent(category)
+                      ? "text-blue-600 font-semibold"
+                      : "text-gray-600"
+                  } hover:text-gray-900`}
+                >
+                  {category}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </nav>
+      </aside>
+    </>
+  );
+}

--- a/front/components/ui/ArticleList.tsx
+++ b/front/components/ui/ArticleList.tsx
@@ -3,13 +3,14 @@ import Article from "./Article";
 
 type Props = {
   articles: ArticleType[];
+  title: string;
 };
 
-export default function ArticleList({ articles }: Props) {
+export default function ArticleList({ articles,title }: Props) {
   return (
     <>
       <div className="mx-auto w-3/4 md:w-3/5 mt-10">
-        <h1 className="text-2xl font-bold mb-4">News</h1>
+        <h1 className="text-2xl font-bold mb-4">{title}</h1>
         <div className="w-full">
           {articles.map((article: ArticleType) => (
             <Article key={article.url} url={article.url} />

--- a/front/components/ui/PostCardList.tsx
+++ b/front/components/ui/PostCardList.tsx
@@ -8,8 +8,7 @@ type Props = {
 export default function CardList({ posts }: Props) {
   return (
     <>
-      <div className="mx-auto w-3/4 md:w-3/5 mt-10">
-        <h1 className="text-2xl font-bold mb-4">投稿一覧</h1>
+      <div className="mx-auto w-3/4 mt-10">
         <div className="w-full">
           {posts.map((post: Post) => (
             <PostCard key={post.id} post={post} />

--- a/front/components/ui/SignOutButton.tsx
+++ b/front/components/ui/SignOutButton.tsx
@@ -9,7 +9,7 @@ export default function SignOutButton() {
       }}
     >
       <button className="px-4 py-2 bg-slate-500 text-white rounded-md hover:bg-slate-600 transition-colors">
-        Sign Out
+        SignOut
       </button>
     </form>
   )

--- a/front/lib/api/news.ts
+++ b/front/lib/api/news.ts
@@ -3,7 +3,7 @@ import { ArticleType } from "@/types/article";
 export const getNews = async () => {
   const API = process.env.NEWS_API_KEY;
   const response = await fetch(
-    `https://newsapi.org/v2/top-headlines?country=us&pageSize=5&apiKey=${API}`,
+    `https://newsapi.org/v2/everything?domains=techcrunch.com&pageSize=5&apiKey=${API}`,
     {
       method: "GET",
       headers: {


### PR DESCRIPTION
## issue番号
close #40 

## やったこと
- マイページにサイドバーを追加しました
- サイドバー上には当該ユーザーのカテゴリ名が一覧表示され、選択したカテゴリにより投稿を絞り込み表示できるよう実装しました


## できなかったこと・やらなかったこと


## できるようになること（ユーザ目線）
- マイページのサイドバーでカテゴリ名をクリックすると、投稿をカテゴリによって絞り込みできます

## できなくなること（ユーザ目線）


## 動作確認
サイドバー（絞り込みなし）
[![Image from Gyazo](https://i.gyazo.com/ff6cc3f2b5c51166328679226c384aea.jpg)](https://gyazo.com/ff6cc3f2b5c51166328679226c384aea)

カテゴリ名による絞り込み
[![Image from Gyazo](https://i.gyazo.com/1ea7cd93033faa08117a1e477b325582.jpg)](https://gyazo.com/1ea7cd93033faa08117a1e477b325582)

絞り込み時のURL
``http://localhost:8000/users/3de277f8-5b4e-49e7-bebd-d43a6dfb1ffb?category=新しいカテゴリ``

上記URLのクエリパラメータはエンコード処理済み
``http://localhost:8000/users/3de277f8-5b4e-49e7-bebd-d43a6dfb1ffb?category=%E6%96%B0%E3%81%97%E3%81%84%E3%82%AB%E3%83%86%E3%82%B4%E3%83%AA``

モバイル表示（モーダルサイドバー）
[![Image from Gyazo](https://i.gyazo.com/e32819a2c0e6b4c6fb91fd869244a743.png)](https://gyazo.com/e32819a2c0e6b4c6fb91fd869244a743)


## その他